### PR TITLE
feat: auto-setup is now skipped in ci environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-hook"
-version = "0.6.5"
+version = "0.7.0"
 authors = ["Swellaby <opensource@swellaby.com>"]
 description = "git hook utility"
 license = "MIT"

--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,10 @@ use std::env;
 use std::process::exit;
 
 fn main() {
+    if ci_info::is_ci() {
+        exit(0);
+    };
+
     let target_directory = env::var("OUT_DIR").unwrap();
     if let Err(err) = rusty_hook::init_directory(
         &closures::get_command_runner(),

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -27,7 +27,7 @@ pub fn get_command_runner() -> fn(cmd: &str, dir: &str) -> Result<String, String
                 if output.status.success() {
                     Ok(String::from_utf8(output.stdout)
                         .unwrap()
-                        .trim_end_matches("\n")
+                        .trim_end_matches('\n')
                         .to_string())
                 } else {
                     Err(format!(


### PR DESCRIPTION
## Changes
<!-- Summary of changes included in this PR -->
- [X] Updates auto-setup during build to check for CI environments, and if CI is detected then auto-setup is skipped
- [X] Fixed clippy issue

## Related Issues
<!-- List any related/impacted issues -->
- Closes #35
