### PR TITLE
fix: exec permission bug on unix systems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "rusty-hook"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "ci_info 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-hook"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Swellaby <opensource@swellaby.com>"]
 description = "git hook utility"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Just add `rusty-hook` as a dev dependency in your Cargo.toml file:
 
 ```toml
 [dev-dependencies]
-rusty-hook = "0.7.1"
+rusty-hook = "0.8.0"
 ```
 
 ## Initialize

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -53,7 +53,11 @@ fn create_file(path: PathBuf, make_executable: bool) -> Result<File, ()> {
             Ok(metadata) => metadata,
             Err(_) => return Err(()),
         };
-        metadata.permissions().set_mode(0o755);
+        let mut permissions = metadata.permissions();
+        permissions.set_mode(0o755);
+        if std::fs::set_permissions(&path, permissions).is_err() {
+            return Err(());
+        };
     };
 
     Ok(file)


### PR DESCRIPTION
## Changes
<!-- Summary of changes included in this PR -->
- [X] Fix the missing exec permission on the hook script files


## Related Issues
<!-- List any related/impacted issues -->
- Closes #41 
