### PR TITLE
feat: improve behavior when config file is missing

### DIFF
--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -28,6 +28,7 @@
     "rustup",
     "sendemail",
     "setvariable",
+    "shellcheck",
     "shiba",
     "swellaby",
     "testresults",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rusty-hook"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "ci_info 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-hook"
-version = "0.8.4"
+version = "0.9.0"
 authors = ["Swellaby <opensource@swellaby.com>"]
 description = "git hook utility"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Just add `rusty-hook` as a dev dependency in your Cargo.toml file:
 
 ```toml
 [dev-dependencies]
-rusty-hook = "0.8.4"
+rusty-hook = "0.9.0"
 ```
 
 ## Initialize

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ verbose = true
 
 const DEFAULT_CONFIG_FILE_NAME: &str = ".rusty-hook.toml";
 const CONFIG_FILE_NAMES: [&str; 2] = [DEFAULT_CONFIG_FILE_NAME, "rusty-hook.toml"];
-const NO_CONFIG_FILE_FOUND: &str = "No config file found";
+pub const NO_CONFIG_FILE_FOUND: &str = "No config file found";
 pub const MISSING_CONFIG_KEY: &str = "Missing config key";
 
 fn find_config_file<F>(root_directory_path: &str, file_exists: F) -> Result<String, String>
@@ -106,14 +106,14 @@ where
     G: Fn(&str) -> Result<bool, ()>,
 {
     let path = match find_config_file(root_directory_path, &file_exists) {
-        Ok(path) => path,
-        Err(_) => {
-            return Err(String::from(NO_CONFIG_FILE_FOUND));
+        Ok(path) => {
+            if path == NO_CONFIG_FILE_FOUND {
+                return Err(String::from(NO_CONFIG_FILE_FOUND));
+            } else {
+                path
+            }
         }
-    };
-
-    if path == NO_CONFIG_FILE_FOUND {
-        return Err(String::from(NO_CONFIG_FILE_FOUND));
+        Err(_) => return Err(String::from(NO_CONFIG_FILE_FOUND)),
     };
 
     match read_file(&path) {

--- a/src/git.rs
+++ b/src/git.rs
@@ -57,7 +57,7 @@ where
             "{{NO_CONFIG_FILE_EXIT_CODE}}",
             &NO_CONFIG_FILE_FOUND_ERROR_CODE.to_string(),
         )
-        .replace("# shellcheck disable=SC2170,SC1083", "");
+        .replace("\n# shellcheck disable=SC2170,SC1083", "");
     for hook in HOOK_NAMES.iter() {
         if write_file(
             &format!("{}/{}/{}", root_directory_path, hooks_directory, hook),

--- a/src/git.rs
+++ b/src/git.rs
@@ -53,11 +53,11 @@ where
     let version = env!("CARGO_PKG_VERSION");
     let hook_file_contents = String::from(HOOK_FILE_TEMPLATE)
         .replace("{{VERSION}}", version)
+        .replace("\n# shellcheck disable=SC2170,SC1083", "")
         .replace(
             "{{NO_CONFIG_FILE_EXIT_CODE}}",
             &NO_CONFIG_FILE_FOUND_ERROR_CODE.to_string(),
-        )
-        .replace("\n# shellcheck disable=SC2170,SC1083", "");
+        );
     for hook in HOOK_NAMES.iter() {
         if write_file(
             &format!("{}/{}/{}", root_directory_path, hooks_directory, hook),

--- a/src/git.rs
+++ b/src/git.rs
@@ -51,13 +51,12 @@ where
         Err(_) => return Err(String::from("Failure determining git hooks directory")),
     };
     let version = env!("CARGO_PKG_VERSION");
+    let exit_code = &NO_CONFIG_FILE_FOUND_ERROR_CODE.to_string();
     let hook_file_contents = String::from(HOOK_FILE_TEMPLATE)
         .replace("{{VERSION}}", version)
         .replace("\n# shellcheck disable=SC2170,SC1083", "")
-        .replace(
-            "{{NO_CONFIG_FILE_EXIT_CODE}}",
-            &NO_CONFIG_FILE_FOUND_ERROR_CODE.to_string(),
-        );
+        .replace("{{NO_CONFIG_FILE_EXIT_CODE}}", exit_code);
+
     for hook in HOOK_NAMES.iter() {
         if write_file(
             &format!("{}/{}/{}", root_directory_path, hooks_directory, hook),

--- a/src/git_test.rs
+++ b/src/git_test.rs
@@ -114,11 +114,11 @@ mod create_hook_files_tests {
         let git_hooks = ".git/hooks";
         let exp_contents = &String::from(HOOK_FILE_TEMPLATE)
             .replace("{{VERSION}}", version)
+            .replace("\n# shellcheck disable=SC2170,SC1083", "")
             .replace(
                 "{{NO_CONFIG_FILE_EXIT_CODE}}",
                 &NO_CONFIG_FILE_FOUND_ERROR_CODE.to_string(),
-            )
-            .replace("\n# shellcheck disable=SC2170,SC1083", "");
+            );
         let run_command = |_cmd: &str, _dir: &str| Ok(String::from(git_hooks));
         let write_file = |path: &str, contents: &str, make_executable: bool| {
             let act_hook = &&path[(path.rfind('/').unwrap() + 1)..];

--- a/src/git_test.rs
+++ b/src/git_test.rs
@@ -118,7 +118,7 @@ mod create_hook_files_tests {
                 "{{NO_CONFIG_FILE_EXIT_CODE}}",
                 &NO_CONFIG_FILE_FOUND_ERROR_CODE.to_string(),
             )
-            .replace("# shellcheck disable=SC2170,SC1083", "");
+            .replace("\n# shellcheck disable=SC2170,SC1083", "");
         let run_command = |_cmd: &str, _dir: &str| Ok(String::from(git_hooks));
         let write_file = |path: &str, contents: &str, make_executable: bool| {
             let act_hook = &&path[(path.rfind('/').unwrap() + 1)..];

--- a/src/git_test.rs
+++ b/src/git_test.rs
@@ -112,13 +112,11 @@ mod create_hook_files_tests {
         let version = env!("CARGO_PKG_VERSION");
         let root_dir = "/usr/repos/foo";
         let git_hooks = ".git/hooks";
-        let exp_contents = &String::from(HOOK_FILE_TEMPLATE)
+        let exit_code = &NO_CONFIG_FILE_FOUND_ERROR_CODE.to_string();
+        let exp_contents = String::from(HOOK_FILE_TEMPLATE)
             .replace("{{VERSION}}", version)
             .replace("\n# shellcheck disable=SC2170,SC1083", "")
-            .replace(
-                "{{NO_CONFIG_FILE_EXIT_CODE}}",
-                &NO_CONFIG_FILE_FOUND_ERROR_CODE.to_string(),
-            );
+            .replace("{{NO_CONFIG_FILE_EXIT_CODE}}", exit_code);
         let run_command = |_cmd: &str, _dir: &str| Ok(String::from(git_hooks));
         let write_file = |path: &str, contents: &str, make_executable: bool| {
             let act_hook = &&path[(path.rfind('/').unwrap() + 1)..];

--- a/src/git_test.rs
+++ b/src/git_test.rs
@@ -112,7 +112,13 @@ mod create_hook_files_tests {
         let version = env!("CARGO_PKG_VERSION");
         let root_dir = "/usr/repos/foo";
         let git_hooks = ".git/hooks";
-        let exp_contents = &String::from(HOOK_FILE_TEMPLATE).replace("{{VERSION}}", version);
+        let exp_contents = &String::from(HOOK_FILE_TEMPLATE)
+            .replace("{{VERSION}}", version)
+            .replace(
+                "{{NO_CONFIG_FILE_EXIT_CODE}}",
+                &NO_CONFIG_FILE_FOUND_ERROR_CODE.to_string(),
+            )
+            .replace("# shellcheck disable=SC2170,SC1083", "");
         let run_command = |_cmd: &str, _dir: &str| Ok(String::from(git_hooks));
         let write_file = |path: &str, contents: &str, make_executable: bool| {
             let act_hook = &&path[(path.rfind('/').unwrap() + 1)..];

--- a/src/hook_script.sh
+++ b/src/hook_script.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# rusty-hook
+# version {{VERSION}}
+
+hookName=$(basename "$0")
+gitParams="$*"
+
+if ! command -v rusty-hook >/dev/null 2>&1; then
+  if [ -z "${RUSTY_HOOK_SKIP_AUTO_INSTALL}" ]; then
+    echo "Finalizing rusty-hook configuration..."
+    echo "This may take a few seconds..."
+    cargo install rusty-hook >/dev/null 2>&1
+  else
+    echo "rusty-hook is not installed, and auto install is disabled"
+    echo "skipping $hookName hook"
+    echo "You can reinstall it using 'cargo install rusty-hook' or delete this hook"
+    exit 0
+  fi
+fi
+
+rusty-hook run --hook "$hookName" "$gitParams"
+rhExitCode=$?
+
+if [ $rhExitCode -ne 0 ]; then
+  # shellcheck disable=SC2170,SC1083
+  if [ $rhExitCode -eq {{NO_CONFIG_FILE_EXIT_CODE}} ]; then
+    if [ "$hookName" = "pre-commit" ]; then
+      echo "rusty-hook git hooks are configured, but no config file was found"
+      echo "In order to use rusty-hook, your project must have a config file"
+      echo "See https://github.com/swellaby/rusty-hook#configure for more information"
+      echo
+      echo "If you were trying to remove rusty-hook, then you should also delete the git hook files to remove this warning"
+      echo
+    fi
+    exit 0
+  else
+    echo "Configured hook command failed"
+    echo "$hookName hook rejected"
+    exit $rhExitCode
+  fi
+fi

--- a/src/hook_script.sh
+++ b/src/hook_script.sh
@@ -22,7 +22,7 @@ rusty-hook run --hook "$hookName" "$gitParams"
 rhExitCode=$?
 
 if [ $rhExitCode -ne 0 ]; then
-  # shellcheck disable=SC2170,SC1083
+# shellcheck disable=SC2170,SC1083
   if [ $rhExitCode -eq {{NO_CONFIG_FILE_EXIT_CODE}} ]; then
     if [ "$hookName" = "pre-commit" ]; then
       echo "rusty-hook git hooks are configured, but no config file was found"

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,8 +56,12 @@ fn run(args: Vec<String>) {
         &closures::get_logger(),
         &hook_name,
     ) {
-        eprintln!("{}", err);
-        exit(1);
+        if err == rusty_hook::NO_CONFIG_FILE_FOUND {
+            exit(rusty_hook::NO_CONFIG_FILE_FOUND_ERROR_CODE);
+        } else {
+            eprintln!("{}", err);
+            exit(1);
+        }
     }
 }
 

--- a/src/rusty_hook_test.rs
+++ b/src/rusty_hook_test.rs
@@ -79,11 +79,22 @@ mod run_tests {
     }
 
     #[test]
-    fn returns_error_when_config_contents_unloadable() {
-        let exp_err = "Failed to locate or parse config file";
+    fn returns_error_when_config_file_missing() {
+        let exp_err = config::NO_CONFIG_FILE_FOUND;
         let run_command = |_cmd: &str, _dir: &str| Ok(String::from(""));
         let read_file = |_file_path: &str| Err(());
         let file_exists = |_path: &str| Ok(false);
+        let log = |_path: &str| panic!("");
+        let result = run(run_command, file_exists, read_file, log, "");
+        assert_eq!(result, Err(String::from(exp_err)));
+    }
+
+    #[test]
+    fn returns_error_when_config_contents_unloadable() {
+        let exp_err = "Failed to parse config file";
+        let run_command = |_cmd: &str, _dir: &str| Ok(String::from(""));
+        let read_file = |_file_path: &str| Err(());
+        let file_exists = |_path: &str| Ok(true);
         let log = |_path: &str| panic!("");
         let result = run(run_command, file_exists, read_file, log, "");
         assert_eq!(result, Err(String::from(exp_err)));
@@ -104,7 +115,7 @@ mod run_tests {
 
     #[test]
     fn returns_error_on_invalid_config() {
-        let exp_err = "Invalid config file";
+        let exp_err = "Invalid rusty-hook config file";
         let contents = "abc";
         let run_command = |_cmd: &str, _dir: &str| Ok(String::from(""));
         let read_file = |_file_path: &str| Ok(String::from(contents));


### PR DESCRIPTION
## Changes
<!-- Summary of changes included in this PR -->
- [X] Externalizes the hook script contents into a script file
- [X] Enhances the `rusty-hook` cli to respond with a specific exit code (currently `3`) when the internal error was a missing config file
- [X] Enhances the git hook scripts to look at the exit code from `rusty-hook`. 
  - Obviously on a zero exit code, everything will pass/proceed as normal
  - On a non-zero exit code, the script will print a message stating which git hook was rejected
  - On a missing config file exit code, the hook will instead exit with `0`, allowing the git hook workflow to continue. The pre-commit hook will also display a **warning** message to the user:
```
rusty-hook git hooks are configured, but no config file was found
In order to use rusty-hook, your project must have a config file
See https://github.com/swellaby/rusty-hook#configure for more information

If you were trying to remove rusty-hook, then you should also delete the git hook files to remove this warning
```

## Related Issues
<!-- List any related/impacted issues -->
- Closes #52 
- Closes #49
