### PR TITLE
ci: update linux pr to use new tarpaulin arg

### DIFF
--- a/.azure-pipelines/build/pr.hook-scripts.yml
+++ b/.azure-pipelines/build/pr.hook-scripts.yml
@@ -19,7 +19,7 @@ steps:
 - task: swellaby.shellcheck.shellcheck.shellcheck@0
   displayName: 'Run ShellCheck analysis'
   inputs:
-    targetFiles: '**/!(shunit2).sh'
+    targetFiles: '**/*.sh'
     followSourcedFiles: true
     checkSourcedFiles: true
     ignoredErrorCodes: |

--- a/.azure-pipelines/build/pr.hook-scripts.yml
+++ b/.azure-pipelines/build/pr.hook-scripts.yml
@@ -19,7 +19,7 @@ steps:
 - task: swellaby.shellcheck.shellcheck.shellcheck@0
   displayName: 'Run ShellCheck analysis'
   inputs:
-    targetFiles: '**/*.sh'
+    targetFiles: '**/!(*.shunit2).sh'
     followSourcedFiles: true
     checkSourcedFiles: true
     ignoredErrorCodes: |

--- a/.azure-pipelines/build/pr.hook-scripts.yml
+++ b/.azure-pipelines/build/pr.hook-scripts.yml
@@ -19,7 +19,7 @@ steps:
 - task: swellaby.shellcheck.shellcheck.shellcheck@0
   displayName: 'Run ShellCheck analysis'
   inputs:
-    targetFiles: '**/!(*.shunit2).sh'
+    targetFiles: '**/!(shunit2).sh'
     followSourcedFiles: true
     checkSourcedFiles: true
     ignoredErrorCodes: |

--- a/.azure-pipelines/build/pr.linux.yml
+++ b/.azure-pipelines/build/pr.linux.yml
@@ -39,9 +39,9 @@ steps:
 
 - bash: |
     set -eo pipefail
-    cargo tarpaulin -o Xml --exclude-files *_test.rs,main.rs
+    cargo tarpaulin -o Xml --exclude-files *_test.rs,main.rs --out-dir .coverage/unit
     cargo junit --name $(Build.SourcesDirectory)/.testresults/unit/junit.xml
-    cp cobertura.xml .coverage/unit/cobertura.xml
+    # cp cobertura.xml .coverage/unit/cobertura.xml
     sudo chmod +rw .coverage -R
     sudo chmod +rw .testresults -R
   displayName: 'Run tests'

--- a/.azure-pipelines/build/pr.linux.yml
+++ b/.azure-pipelines/build/pr.linux.yml
@@ -39,7 +39,7 @@ steps:
 
 - bash: |
     set -eo pipefail
-    cargo tarpaulin -o Xml --exclude-files *_test.rs,main.rs --out-dir .coverage/unit
+    cargo tarpaulin -o Xml --exclude-files *_test.rs,main.rs --output-dir .coverage/unit
     cargo junit --name $(Build.SourcesDirectory)/.testresults/unit/junit.xml
     # cp cobertura.xml .coverage/unit/cobertura.xml
     sudo chmod +rw .coverage -R

--- a/tests/hook_files/shunit2.sh
+++ b/tests/hook_files/shunit2.sh
@@ -17,7 +17,7 @@
 #   shellcheck disable=SC2006
 # expr may be antiquated, but it is the only solution in some cases.
 #   shellcheck disable=SC2003
-
+# shellcheck disable=SC2254
 # Return if shunit2 already loaded.
 command [ -n "${SHUNIT_VERSION:-}" ] && exit 0
 SHUNIT_VERSION='2.1.8pre'


### PR DESCRIPTION
## Changes
<!-- Summary of changes included in this PR -->
- [X] Leverage new tarpaulin `--output-dir` arg for test result files
- [x] Excludes vendored shunit file from shellcheck scan job

## Related Issues
<!-- List any related/impacted issues -->
- Closes #75 
- Closes #77 
