### PR TITLE
Add Cargo bin info to docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-hook"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Swellaby <opensource@swellaby.com>"]
 description = "git hook utility"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Just add `rusty-hook` as a dev dependency in your Cargo.toml file:
 
 ```toml
 [dev-dependencies]
-rusty-hook = "^0.11.1"
+rusty-hook = "^0.11.2"
 ```
 
 ## Initialize

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ Functional, but still in Beta!
 [![Linux CI Badge][linux-ci-badge]][linux-ci-url]
 [![Mac CI Badge][mac-ci-badge]][mac-ci-url]
 [![Windows CI Badge][windows-ci-badge]][windows-ci-url]  
-
 [![Test Results Badge][tests-badge]][tests-url]
 [![Coverage Badge][coverage-badge]][coverage-url]
 
 ## Quick Start
+Pre-requisites: Make sure you have Rust installed and that Cargo's bin directory is on your PATH. 
+https://www.rust-lang.org/tools/install
+
 1. Add `rusty-hook` as a dev dependency in your Cargo.toml file
 2. Run `cargo test` (to build your dev dependencies, including `rusty-hook`)
 3. Update the generated `.rusty-hook.toml` file with the commands you want to run


### PR DESCRIPTION
## Changes
<!-- Summary of changes included in this PR -->
- [x] Include prerequisite information about Rust installation and cargo bin dir on path

## Related Issues
<!-- List any related/impacted issues -->
- Closes #105 
