### PR TITLE
Changed multiline strings to use raw string literals

### DIFF
--- a/src/config_test.rs
+++ b/src/config_test.rs
@@ -180,25 +180,25 @@ mod get_table_key_value_from_config {
 
     #[test]
     fn handles_missing_table() {
-        let contents = "[hooks]";
+        let contents = r#"[hooks]"#;
         let result = get_table_key_value_from_config(contents, "foo", "");
         assert_eq!(result, Err(String::from("Missing config table")));
     }
 
     #[test]
     fn handles_missing_table_key() {
-        let contents = "[hooks]
+        let contents = r#"[hooks]
             pre-commit = 'cargo test'
-        ";
+        "#;
         let result = get_table_key_value_from_config(contents, "hooks", "pre-push");
         assert_eq!(result, Err(String::from("Missing config key")));
     }
 
     #[test]
     fn parses_hook_value() {
-        let contents = "[hooks]
+        let contents = r#"[hooks]
             pre-commit = 'cargo test'
-        ";
+        "#;
         let table = "hooks";
         let key = "pre-commit";
         let exp_value = "cargo test";
@@ -223,18 +223,18 @@ mod get_log_setting_tests {
 
     #[test]
     fn returns_true_when_log_not_boolean() {
-        let contents = "[logging]
+        let contents = r#"[logging]
             verbose = 'cargo test'
-        ";
+        "#;
         let result = get_log_setting(contents);
         assert_eq!(result, true);
     }
 
     #[test]
     fn returns_result_when_value_valid() {
-        let contents = "[logging]
+        let contents = r#"[logging]
             verbose = false
-        ";
+        "#;
         let result = get_log_setting(contents);
         assert_eq!(result, false);
     }
@@ -253,18 +253,18 @@ mod get_hook_script_tests {
 
     #[test]
     fn returns_err_when_hook_not_string() {
-        let contents = "[hooks]
+        let contents = r#"[hooks]
             pre-push = false
-        ";
+        "#;
         let result = get_hook_script(contents, "pre-push");
         assert_eq!(result, Err(String::from("Invalid hook config")));
     }
 
     #[test]
     fn returns_result_when_value_valid() {
-        let contents = "[hooks]
+        let contents = r#"[hooks]
             pre-commit = 'cargo test'
-        ";
+        "#;
         let result = get_hook_script(contents, "pre-commit");
         assert_eq!(result.unwrap(), "cargo test");
     }

--- a/src/config_test.rs
+++ b/src/config_test.rs
@@ -180,7 +180,7 @@ mod get_table_key_value_from_config {
 
     #[test]
     fn handles_missing_table() {
-        let contents = r#"[hooks]"#;
+        let contents = "[hooks]";
         let result = get_table_key_value_from_config(contents, "foo", "");
         assert_eq!(result, Err(String::from("Missing config table")));
     }
@@ -188,7 +188,7 @@ mod get_table_key_value_from_config {
     #[test]
     fn handles_missing_table_key() {
         let contents = r#"[hooks]
-            pre-commit = 'cargo test'
+            pre-commit = "cargo test"
         "#;
         let result = get_table_key_value_from_config(contents, "hooks", "pre-push");
         assert_eq!(result, Err(String::from("Missing config key")));
@@ -197,7 +197,7 @@ mod get_table_key_value_from_config {
     #[test]
     fn parses_hook_value() {
         let contents = r#"[hooks]
-            pre-commit = 'cargo test'
+            pre-commit = "cargo test"
         "#;
         let table = "hooks";
         let key = "pre-commit";
@@ -224,7 +224,7 @@ mod get_log_setting_tests {
     #[test]
     fn returns_true_when_log_not_boolean() {
         let contents = r#"[logging]
-            verbose = 'cargo test'
+            verbose = "cargo test"
         "#;
         let result = get_log_setting(contents);
         assert_eq!(result, true);
@@ -232,9 +232,9 @@ mod get_log_setting_tests {
 
     #[test]
     fn returns_result_when_value_valid() {
-        let contents = r#"[logging]
+        let contents = "[logging]
             verbose = false
-        "#;
+        ";
         let result = get_log_setting(contents);
         assert_eq!(result, false);
     }
@@ -253,9 +253,9 @@ mod get_hook_script_tests {
 
     #[test]
     fn returns_err_when_hook_not_string() {
-        let contents = r#"[hooks]
+        let contents = "[hooks]
             pre-push = false
-        "#;
+        ";
         let result = get_hook_script(contents, "pre-push");
         assert_eq!(result, Err(String::from("Invalid hook config")));
     }
@@ -263,7 +263,7 @@ mod get_hook_script_tests {
     #[test]
     fn returns_result_when_value_valid() {
         let contents = r#"[hooks]
-            pre-commit = 'cargo test'
+            pre-commit = "cargo test"
         "#;
         let result = get_hook_script(contents, "pre-commit");
         assert_eq!(result.unwrap(), "cargo test");

--- a/src/rusty_hook_test.rs
+++ b/src/rusty_hook_test.rs
@@ -139,12 +139,12 @@ mod run_tests {
 
     #[test]
     fn does_not_log_details_when_disabled() {
-        let contents = "[hooks]
+        let contents = r#"[hooks]
             pre-commit = 'cargo test'
 
             [logging]
             verbose = false
-        ";
+        "#;
         let run_command = |cmd: &str, _dir: Option<&str>, stream_io: bool| {
             if cmd == "cargo test" && stream_io {
                 panic!("")
@@ -164,12 +164,12 @@ mod run_tests {
 
     #[test]
     fn logs_details_when_enabled() {
-        let contents = "[hooks]
+        let contents = r#"[hooks]
             pre-commit = 'cargo test'
 
             [logging]
             verbose = true
-        ";
+        "#;
         let run_command = |cmd: &str, _dir: Option<&str>, stream_io: bool| {
             if cmd == "cargo test" && !stream_io {
                 panic!("")
@@ -189,12 +189,12 @@ mod run_tests {
 
     #[test]
     fn returns_ok_when_script_succeeds() {
-        let contents = "[hooks]
+        let contents = r#"[hooks]
             pre-commit = 'cargo test'
 
             [logging]
             verbose = false
-        ";
+        "#;
         let run_command =
             |_cmd: &str, _dir: Option<&str>, _stream_io: bool| Ok(Some(String::from("")));
         let read_file = |_file_path: &str| Ok(String::from(contents));
@@ -207,12 +207,12 @@ mod run_tests {
     #[test]
     fn returns_err_when_script_fails() {
         let exp_err = "crashed";
-        let contents = "[hooks]
+        let contents = r#"[hooks]
             pre-commit = 'cargo test'
 
             [logging]
             verbose = false
-        ";
+        "#;
         let run_command = |cmd: &str, _dir: Option<&str>, _stream_io: bool| {
             if cmd == "cargo test" {
                 return Err(Some(String::from(exp_err)));

--- a/src/rusty_hook_test.rs
+++ b/src/rusty_hook_test.rs
@@ -140,7 +140,7 @@ mod run_tests {
     #[test]
     fn does_not_log_details_when_disabled() {
         let contents = r#"[hooks]
-            pre-commit = 'cargo test'
+            pre-commit = "cargo test"
 
             [logging]
             verbose = false
@@ -165,7 +165,7 @@ mod run_tests {
     #[test]
     fn logs_details_when_enabled() {
         let contents = r#"[hooks]
-            pre-commit = 'cargo test'
+            pre-commit = "cargo test"
 
             [logging]
             verbose = true
@@ -190,7 +190,7 @@ mod run_tests {
     #[test]
     fn returns_ok_when_script_succeeds() {
         let contents = r#"[hooks]
-            pre-commit = 'cargo test'
+            pre-commit = "cargo test"
 
             [logging]
             verbose = false
@@ -208,7 +208,7 @@ mod run_tests {
     fn returns_err_when_script_fails() {
         let exp_err = "crashed";
         let contents = r#"[hooks]
-            pre-commit = 'cargo test'
+            pre-commit = "cargo test"
 
             [logging]
             verbose = false


### PR DESCRIPTION
## Changes
<!-- Summary of changes included in this PR -->
- Used raw string literals in tests that display a toml file or multiline strings
This is probably not complete. Where do we want raw string literals? Only in multiline strings -> complete, Somewhere different -> not complete

## Related Issues
<!-- List any related/impacted issues -->
- Mentioned in #116 by @calebcartwright 
