### PR TITLE
Changed logging output to always include a prefix of '[rusty-hook] '

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ Here's an example `rusty-hook` configuration that leverages multiple [git hooks]
 ```toml
 [hooks]
 pre-commit = "cargo test"
-pre-push = "cargo fmt -- --check"
+pre-push = ["cargo check", "cargo fmt -- --check"]
 post-commit = "echo yay"
 
 [logging]
 verbose = true
 ```
 ### Hooks
-Under the `[hooks]` table, you can add an entry for any and every git hook you want to run by adding a key using the name of the [git hook][git hooks], and then specify the command/script you want to run for that hook. Whenever that git hook is triggered, `rusty-hook` will run your specified command!
+Under the `[hooks]` table, you can add an entry for any and every git hook you want to run by adding a key using the name of the [git hook][git hooks], and then specify the command/script you want to run for that hook. Multiple commands in a form of a toml array are also allowed. Whenever that git hook is triggered, `rusty-hook` will run your specified command!
 
 #### Using git arguments
 In git hook commands, any instance of `%rh!` will be replaced by the arguments that git passes to this hook.  

--- a/src/hook_files/cli.sh
+++ b/src/hook_files/cli.sh
@@ -14,14 +14,14 @@ allowPrereleaseCliVersion={{MINIMUM_ALLOW_PRE}}
 noConfigFileExitCode={{NO_CONFIG_FILE_EXIT_CODE}}
 
 upgradeRustyHookCli() {
-  echo "Upgrading rusty-hook cli..."
-  echo "This may take a few seconds..."
+  echo "[rusty-hook] Upgrading rusty-hook cli..."
+  echo "[rusty-hook] This may take a few seconds..."
   cargo install --force rusty-hook >/dev/null 2>&1
 }
 
 installRustyHookCli() {
-  echo "Finalizing rusty-hook configuration..."
-  echo "This may take a few seconds..."
+  echo "[rusty-hook] Finalizing rusty-hook configuration..."
+  echo "[rusty-hook] This may take a few seconds..."
   cargo install rusty-hook >/dev/null 2>&1
 }
 
@@ -46,18 +46,18 @@ handleRustyHookCliResult() {
   # shellcheck disable=SC2086
   if [ ${rustyHookExitCode} -eq ${noConfigFileExitCode} ]; then
     if [ "${hookName}" = "pre-commit" ]; then
-      echo "rusty-hook git hooks are configured, but no config file was found"
-      echo "In order to use rusty-hook, your project must have a config file"
-      echo "See https://github.com/swellaby/rusty-hook#configure for more information about configuring rusty-hook"
+      echo "[rusty-hook] rusty-hook git hooks are configured, but no config file was found"
+      echo "[rusty-hook] In order to use rusty-hook, your project must have a config file"
+      echo "[rusty-hook] See https://github.com/swellaby/rusty-hook#configure for more information about configuring rusty-hook"
       echo
-      echo "If you were trying to remove rusty-hook, then you should also delete the git hook files to remove this warning"
-      echo "See https://github.com/swellaby/rusty-hook#removing-rusty-hook for more information about removing rusty-hook from your project"
+      echo "[rusty-hook] If you were trying to remove rusty-hook, then you should also delete the git hook files to remove this warning"
+      echo "[rusty-hook] See https://github.com/swellaby/rusty-hook#removing-rusty-hook for more information about removing rusty-hook from your project"
       echo
     fi
     exit 0
   else
-    echo "Configured hook command failed"
-    echo "${hookName} hook rejected"
+    echo "[rusty-hook] Configured hook command failed"
+    echo "[rusty-hook] ${hookName} hook rejected"
     # shellcheck disable=SC2086
     exit ${rustyHookExitCode}
   fi

--- a/src/hook_files/hook_script.sh
+++ b/src/hook_files/hook_script.sh
@@ -12,9 +12,9 @@ if ! command -v rusty-hook >/dev/null 2>&1; then
   if [ -z "${RUSTY_HOOK_SKIP_AUTO_INSTALL}" ]; then
     installRustyHookCli
   else
-    echo "rusty-hook is not installed, and auto install is disabled"
-    echo "skipping ${hookName} hook"
-    echo "You can reinstall it using 'cargo install rusty-hook' or delete this hook"
+    echo "[rusty-hook] rusty-hook is not installed, and auto install is disabled"
+    echo "[rusty-hook] skipping ${hookName} hook"
+    echo "[rusty-hook] You can reinstall it using 'cargo install rusty-hook' or delete this hook"
     exit 0
   fi
 else

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ enum RustyHookOpts {
 
 fn init() {
     if ci_info::is_ci() {
-        println!("CI Environment detected. Skipping hook install");
+        println!("[rusty-hook] CI Environment detected. Skipping hook install");
         exit(0);
     }
 
@@ -37,7 +37,7 @@ fn init() {
         nias::get_file_existence_checker(),
     ) {
         eprintln!(
-            "Fatal error encountered during initialization. Details: {}",
+            "[rusty-hook] Fatal error encountered during initialization. Details: {}",
             err
         );
         exit(1);
@@ -58,7 +58,7 @@ fn run(hook: String, args: Option<String>) {
                 exit(rusty_hook::NO_CONFIG_FILE_FOUND_ERROR_CODE);
             }
             Some(e) => {
-                eprintln!("{}", e);
+                eprintln!("[rusty-hook] {}", e);
                 exit(1);
             }
             None => exit(1),

--- a/src/rusty_hook.rs
+++ b/src/rusty_hook.rs
@@ -117,7 +117,7 @@ where
     };
 
     let message = format!(
-        "Found configured hook: {}\nRunning command: {}",
+        "[rusty-hook] Found configured hook: {}\n[rusty-hook] Running command: {}\n",
         hook_name, script
     );
     log(&message, log_details);

--- a/tests/hook_files/cli.sh
+++ b/tests/hook_files/cli.sh
@@ -36,12 +36,12 @@ testHandlesNonPreCommitHookCorrectlyWhenRustyHookExitCodeIsNoConfigFile() {
 testHandlesPreCommitHookCorrectlyWhenRustyHookExitCodeIsNoConfigFile() {
   hook="pre-commit"
   {
-    echo "rusty-hook git hooks are configured, but no config file was found";
-    echo "In order to use rusty-hook, your project must have a config file";
-    echo "See https://github.com/swellaby/rusty-hook#configure for more information about configuring rusty-hook"
+    echo "[rusty-hook] rusty-hook git hooks are configured, but no config file was found";
+    echo "[rusty-hook] In order to use rusty-hook, your project must have a config file";
+    echo "[rusty-hook] See https://github.com/swellaby/rusty-hook#configure for more information about configuring rusty-hook"
     echo;
-    echo "If you were trying to remove rusty-hook, then you should also delete the git hook files to remove this warning";
-    echo "See https://github.com/swellaby/rusty-hook#removing-rusty-hook for more information about removing rusty-hook from your project";
+    echo "[rusty-hook] If you were trying to remove rusty-hook, then you should also delete the git hook files to remove this warning";
+    echo "[rusty-hook] See https://github.com/swellaby/rusty-hook#removing-rusty-hook for more information about removing rusty-hook from your project";
     echo;
 
   } >> "${expectedStdoutF}"
@@ -58,8 +58,8 @@ testHandlesPreCommitHookCorrectlyWhenRustyHookExitCodeIsNoConfigFile() {
 
 testHandlesCorrectlyWhenRustyHookExitCodeIsOne() {
   hook="pre-push"
-  echo "Configured hook command failed" >> "${expectedStdoutF}"
-  echo "${hook} hook rejected" >> "${expectedStdoutF}"
+  echo "[rusty-hook] Configured hook command failed" >> "${expectedStdoutF}"
+  echo "[rusty-hook] ${hook} hook rejected" >> "${expectedStdoutF}"
   expOutput=$(cat "${expectedStdoutF}")
   expExitCode=1
   (


### PR DESCRIPTION
## Changes
<!-- Summary of changes included in this PR -->
- Changed logging output to always include a prefix of '[rusty-hook] '

## Related Issues
<!-- List any related/impacted issues -->
- Closes #102 
