### PR TITLE
Upgrade ci_info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ci_info"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec64bc9402fde83d980d8f8d493b367bd4e3ba3f44a0b904b6047bedfed293fb"
+dependencies = [
+ "envmnt",
+]
+
+[[package]]
 name = "clap"
 version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,7 +193,8 @@ dependencies = [
 name = "rusty-hook"
 version = "0.12.0"
 dependencies = [
- "ci_info",
+ "ci_info 0.11.0",
+ "ci_info 0.13.0",
  "clap",
  "nias",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ exclude = [
 ]
 
 [dependencies]
-ci_info = "0.11.0"
+ci_info = "0.13.0"
 clap = "3.0.0-beta.2"
 toml = "0.5.7"
 nias = "0.7.0"


### PR DESCRIPTION
## Changes
Upgrading ci_info to 0.13
In 0.13 i removed serde feature which should improve the overall installation time.