### PR TITLE
Update the Linux pipelines to use latest ubuntu vm image

### DIFF
--- a/.azure-pipelines/build/pr.hook-scripts.yml
+++ b/.azure-pipelines/build/pr.hook-scripts.yml
@@ -1,26 +1,26 @@
 trigger:
-- master
+  - master
 
 pr:
-- master
+  - master
 
 pool:
-  vmImage: 'Ubuntu-16.04'
+  vmImage: "ubuntu-latest"
 
 steps:
-- script: ./tests/hook_files/run_tests.sh
-  displayName: 'Run unit tests'
+  - script: ./tests/hook_files/run_tests.sh
+    displayName: "Run unit tests"
 
-- task: swellaby.shellcheck.install-shellcheck.install-shellcheck@0
-  displayName: 'Install ShellCheck'
-  inputs:
-    version: latest
+  - task: swellaby.shellcheck.install-shellcheck.install-shellcheck@0
+    displayName: "Install ShellCheck"
+    inputs:
+      version: latest
 
-- task: swellaby.shellcheck.shellcheck.shellcheck@0
-  displayName: 'Run ShellCheck analysis'
-  inputs:
-    targetFiles: '**/!(shunit2).sh'
-    followSourcedFiles: true
-    checkSourcedFiles: false
-    ignoredErrorCodes: |
-      SC2039
+  - task: swellaby.shellcheck.shellcheck.shellcheck@0
+    displayName: "Run ShellCheck analysis"
+    inputs:
+      targetFiles: "**/!(shunit2).sh"
+      followSourcedFiles: true
+      checkSourcedFiles: false
+      ignoredErrorCodes: |
+        SC2039

--- a/.azure-pipelines/build/pr.mac.yml
+++ b/.azure-pipelines/build/pr.mac.yml
@@ -1,41 +1,41 @@
 trigger:
-- master
+  - master
 
 pr:
-- master
+  - master
 
 pool:
   vmImage: macos-10.14
 
 steps:
-- script: |
-    curl https://sh.rustup.rs -sSf | sh -s -- -y
-    echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
-    echo "##vso[task.setvariable variable=cargoBinPath;]$HOME/.cargo/bin"
-  displayName: 'Install Rust'
+  - script: |
+      curl https://sh.rustup.rs -sSf | sh -s -- -y
+      echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
+      echo "##vso[task.setvariable variable=cargoBinPath;]$HOME/.cargo/bin"
+    displayName: "Install Rust"
 
-- task: DownloadPipelineArtifact@0
-  displayName: 'Download cargo-junit executable'
-  inputs:
-    pipelineId: 1447
-    artifactName: 'cargo-junit'
-    targetPath: '$(cargoBinPath)'
+  - task: DownloadPipelineArtifact@0
+    displayName: "Download cargo-junit executable"
+    inputs:
+      pipelineId: 1447
+      artifactName: "cargo-junit"
+      targetPath: "$(cargoBinPath)"
 
-- script: |
-    sudo chmod +rwx $(cargoBinPath)/cargo-junit
-    mkdir -p .testresults/unit
-  displayName: 'Prep test tools'
+  - script: |
+      sudo chmod +rwx $(cargoBinPath)/cargo-junit
+      mkdir -p .testresults/unit
+    displayName: "Prep test tools"
 
-- script: |
-    set -eo pipefail
-    cargo test --no-run
-    cargo junit --name .testresults/unit/junit.xml
-  displayName: 'Run tests'
+  - script: |
+      set -eo pipefail
+      cargo test --no-run
+      cargo junit --name .testresults/unit/junit.xml
+    displayName: "Run tests"
 
-- task: PublishTestResults@2
-  displayName: 'Publish unit test results'
-  inputs:
-    testResultsFormat: JUnit
-    testResultsFiles: 'junit.xml'
-    searchFolder: $(Build.SourcesDirectory)/.testresults/unit
-    testRunTitle: 'rusty-hook::Unit Tests::Mac PR - Build $(Build.BuildId)'
+  - task: PublishTestResults@2
+    displayName: "Publish unit test results"
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: "junit.xml"
+      searchFolder: $(Build.SourcesDirectory)/.testresults/unit
+      testRunTitle: "rusty-hook::Unit Tests::Mac PR - Build $(Build.BuildId)"

--- a/.azure-pipelines/build/pr.windows.yml
+++ b/.azure-pipelines/build/pr.windows.yml
@@ -1,45 +1,45 @@
 trigger:
-- master
+  - master
 
 pr:
-- master
+  - master
 
 pool:
   vmImage: windows-2019
 
 steps:
-- powershell: |
-   $ProgressPreference = "SilentlyContinue"
-   Invoke-WebRequest https://win.rustup.rs/ -OutFile rustup-init.exe
-   .\rustup-init.exe -y --default-host=x86_64-pc-windows-msvc --profile=minimal
-   del rustup-init.exe
-   echo "##vso[task.setvariable variable=PATH;]$env:USERPROFILE\.cargo\bin;$env:PATH"
-   echo "##vso[task.setvariable variable=cargoBinPath;]$env:USERPROFILE\.cargo\bin"
-  displayName: 'Install Rust'
+  - powershell: |
+      $ProgressPreference = "SilentlyContinue"
+      Invoke-WebRequest https://win.rustup.rs/ -OutFile rustup-init.exe
+      .\rustup-init.exe -y --default-host=x86_64-pc-windows-msvc --profile=minimal
+      del rustup-init.exe
+      echo "##vso[task.setvariable variable=PATH;]$env:USERPROFILE\.cargo\bin;$env:PATH"
+      echo "##vso[task.setvariable variable=cargoBinPath;]$env:USERPROFILE\.cargo\bin"
+    displayName: "Install Rust"
 
-- script: |
-    where rustup
-    rustup component remove rust-docs
-    rustup update stable
-  displayName: 'Setup'
+  - script: |
+      where rustup
+      rustup component remove rust-docs
+      rustup update stable
+    displayName: "Setup"
 
-- task: DownloadPipelineArtifact@0
-  displayName: 'Download cargo-junit executable'
-  inputs:
-    pipelineId: 1448
-    artifactName: 'cargo-junit'
-    targetPath: '$(cargoBinPath)'
+  - task: DownloadPipelineArtifact@0
+    displayName: "Download cargo-junit executable"
+    inputs:
+      pipelineId: 1448
+      artifactName: "cargo-junit"
+      targetPath: "$(cargoBinPath)"
 
-- script: |
-    cargo test --no-run
-    mkdir $(Build.SourcesDirectory)\.testresults\unit
-    cargo junit --name $(Build.SourcesDirectory)\.testresults\unit\junit.xml
-  displayName: 'Run tests'
+  - script: |
+      cargo test --no-run
+      mkdir $(Build.SourcesDirectory)\.testresults\unit
+      cargo junit --name $(Build.SourcesDirectory)\.testresults\unit\junit.xml
+    displayName: "Run tests"
 
-- task: PublishTestResults@2
-  displayName: 'Publish unit test results'
-  inputs:
-    testResultsFormat: JUnit
-    testResultsFiles: 'junit.xml'
-    searchFolder: $(Build.SourcesDirectory)/.testresults/unit
-    testRunTitle: 'rusty-hook::Unit Tests::Windows PR - Build $(Build.BuildId)'
+  - task: PublishTestResults@2
+    displayName: "Publish unit test results"
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: "junit.xml"
+      searchFolder: $(Build.SourcesDirectory)/.testresults/unit
+      testRunTitle: "rusty-hook::Unit Tests::Windows PR - Build $(Build.BuildId)"

--- a/.azure-pipelines/pull-requests/clippy.yml
+++ b/.azure-pipelines/pull-requests/clippy.yml
@@ -1,23 +1,23 @@
 trigger: none
 
 pr:
-- master
+  - master
 
 pool:
-  vmImage: 'Ubuntu-16.04'
+  vmImage: "ubuntu-latest"
 
 steps:
-- script: |
-    curl https://sh.rustup.rs -sSf | sh -s -- -y
-    echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
-    echo "##vso[task.setvariable variable=cargoBinPath;]$HOME/.cargo/bin"
-  displayName: 'Install Rust'
+  - script: |
+      curl https://sh.rustup.rs -sSf | sh -s -- -y
+      echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
+      echo "##vso[task.setvariable variable=cargoBinPath;]$HOME/.cargo/bin"
+    displayName: "Install Rust"
 
-- script: |
-    rustup component add clippy
-  displayName: 'Install clippy'
+  - script: |
+      rustup component add clippy
+    displayName: "Install clippy"
 
-- script: |
-    set -eo pipefail
-    cargo clippy --all-targets -- -D warnings
-  displayName: 'Run clippy'
+  - script: |
+      set -eo pipefail
+      cargo clippy --all-targets -- -D warnings
+    displayName: "Run clippy"

--- a/.azure-pipelines/pull-requests/rustfmt.yml
+++ b/.azure-pipelines/pull-requests/rustfmt.yml
@@ -1,24 +1,23 @@
 trigger: none
 
 pr:
-- master
+  - master
 
 pool:
-  vmImage: 'Ubuntu-16.04'
+  vmImage: "ubuntu-latest"
 
 steps:
-- script: |
-    curl https://sh.rustup.rs -sSf | sh -s -- -y
-    echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
-    echo "##vso[task.setvariable variable=cargoBinPath;]$HOME/.cargo/bin"
-  displayName: 'Install Rust'
+  - script: |
+      curl https://sh.rustup.rs -sSf | sh -s -- -y
+      echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
+      echo "##vso[task.setvariable variable=cargoBinPath;]$HOME/.cargo/bin"
+    displayName: "Install Rust"
 
-- script: |
-    rustup component add rustfmt
-  displayName: 'Install rustfmt'
+  - script: |
+      rustup component add rustfmt
+    displayName: "Install rustfmt"
 
-- script: |
-    set -eo pipefail
-    cargo fmt -- --check
-  displayName: 'Run rustfmt'
-
+  - script: |
+      set -eo pipefail
+      cargo fmt -- --check
+    displayName: "Run rustfmt"


### PR DESCRIPTION
## Changes
<!-- Summary of changes included in this PR -->
- [x] Update vm image to `ubuntu-latest`
- [x] Format with prettier

As discussed in #166 this updates the vm images to the latest version of ubuntu. I was unsure whether it was preferable to go with an explicit version (`ubuntu-20.04`), so please let me know if that would be preferred.

I couldn't find any formatting or linting recommendations for the files. By default my editor uses `prettier`, so I also formatted the non-linux pipelines to keep the style consistent. Let me know if I should undo the formatting or use a different tool :slightly_smiling_face:
